### PR TITLE
Fix: Configure Decap CMS for Netlify Identity

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,151 @@
+backend:
+  name: git-gateway
+  branch: main # Branch to update (optional; defaults to master)
+
+# Uncomment below to enable drafts
+# publish_mode: editorial_workflow
+
+media_folder: "images/uploads" # Media files will be stored in the repo under images/uploads
+public_folder: "/images/uploads" # The src attribute for uploaded media will begin with /images/uploads
+
+collections:
+  # Service Information Collection
+  - name: "service_info"
+    label: "Service Information"
+    folder: "content/service"
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    fields:
+      - {label: "Title", name: "title", widget: "string", default: "This Sunday's Service"}
+      - {label: "Date", name: "date", widget: "datetime"}
+      - {label: "Service Date", name: "service_date", widget: "string", hint: "e.g., 27th July, 2025"}
+      - {label: "Collect", name: "collect", widget: "string", hint: "e.g., 6th Sunday After Trinity"}
+      - {label: "Liturgical Colour", name: "liturgical_colour", widget: "select", options: ["Red", "Green", "Purple", "White", "Gold", "Blue"]}
+      - {label: "Theme", name: "theme", widget: "string", hint: "e.g., Minister's Appreciation Day"}
+      - {label: "Special Notes", name: "notes", widget: "text", required: false}
+
+  # Announcements Collection
+  - name: "announcements"
+    label: "Announcements"
+    folder: "content/announcements"
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Category", name: "category", widget: "select", options: ["Weekly/Monthly Services", "Upcoming Events", "Church Needs", "General"]}
+      - {label: "Content", name: "body", widget: "markdown"}
+      - {label: "Priority", name: "priority", widget: "select", options: ["High", "Medium", "Low"], default: "Medium"}
+      - {label: "Publish Date", name: "date", widget: "datetime"}
+      - {label: "Expiry Date", name: "expiry", widget: "datetime", required: false, hint: "When should this announcement be removed?"}
+
+  # Prayer Points Collection
+  - name: "prayer_devotion"
+    label: "Prayer & Devotion"
+    folder: "content/prayer"
+    create: true
+    slug: "{{year}}-week-{{slug}}"
+    fields:
+      - {label: "Title", name: "title", widget: "string", default: "Prayer Points for the Week"}
+      - {label: "Week Starting", name: "week_start", widget: "date"}
+      - {label: "Prayer Points", name: "prayer_points", widget: "list", field: {label: "Prayer Point", name: "point", widget: "string"}}
+      - {label: "Food for Thought", name: "food_for_thought", widget: "text"}
+      - {label: "Scripture Reference", name: "scripture", widget: "string", required: false}
+
+  # Events Collection
+  - name: "church_events"
+    label: "Church Events"
+    folder: "content/events"
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    fields:
+      - {label: "Event Title", name: "title", widget: "string"}
+      - {label: "Event Date", name: "event_date", widget: "datetime"}
+      - {label: "Description", name: "description", widget: "text"}
+      - {label: "Event Flyer", name: "flyer", widget: "image", required: false}
+      - {label: "Location", name: "location", widget: "string", default: "Salem African Church, Abekoko Parish"}
+      - {label: "Contact Person", name: "contact", widget: "string", required: false}
+      - {label: "Registration Required", name: "registration", widget: "boolean", default: false}
+      - {label: "Event Type", name: "type", widget: "select", options: ["Service", "Fellowship", "Outreach", "Meeting", "Celebration", "Other"]}
+
+  # Gallery Collection
+  - name: "photo_gallery"
+    label: "Photo Gallery"
+    folder: "content/gallery"
+    create: true
+    slug: "{{year}}-{{month}}-{{slug}}"
+    fields:
+      - {label: "Album Title", name: "title", widget: "string"}
+      - {label: "Date", name: "date", widget: "date"}
+      - {label: "Description", name: "description", widget: "text", required: false}
+      - {label: "Photos", name: "photos", widget: "list", fields: [
+          {label: "Image", name: "image", widget: "image"},
+          {label: "Caption", name: "caption", widget: "string", required: false}
+        ]}
+      - {label: "Event Type", name: "category", widget: "select", options: ["Gethsemane", "Sunday Service", "Special Events", "Community Outreach", "Celebrations", "Other"]}
+
+  # Church Information Collection
+  - name: "church_info"
+    label: "Church Information"
+    folder: "content/church"
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - {label: "Section", name: "title", widget: "string"}
+      - {label: "Content Type", name: "type", widget: "select", options: ["Contact", "Leadership", "About", "Account Details"]}
+      - {label: "Content", name: "body", widget: "markdown"}
+      - {label: "Last Updated", name: "date", widget: "datetime"}
+
+  # Leadership Collection
+  - name: "church_leadership"
+    label: "Church Leadership"
+    folder: "content/leadership"
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - {label: "Name", name: "name", widget: "string"}
+      - {label: "Position", name: "position", widget: "string"}
+      - {label: "Photo", name: "photo", widget: "image", required: false}
+      - {label: "Bio", name: "bio", widget: "text", required: false}
+      - {label: "Contact", name: "contact", widget: "string", required: false}
+      - {label: "Order", name: "order", widget: "number", default: 1, hint: "Display order (1 = first)"}
+
+  # Settings Collection (Single file)
+  - name: "website_settings"
+    label: "Website Settings"
+    files:
+      - label: "General Settings"
+        name: "general_settings"
+        file: "content/settings/general.yml"
+        fields:
+          - {label: "Church Name", name: "church_name", widget: "string", default: "Salem African Church of Christ"}
+          - {label: "Parish", name: "parish", widget: "string", default: "Abekoko Parish, Agege Lagos"}
+          - {label: "Tagline", name: "tagline", widget: "string", default: "Stay Updated • Stay Blessed"}
+          - {label: "Phone", name: "phone", widget: "string"}
+          - {label: "Email", name: "email", widget: "string"}
+          - {label: "Address", name: "address", widget: "text"}
+          - {label: "Service Times", name: "service_times", widget: "list", field: {label: "Service", name: "service", widget: "string"}}
+
+      - label: "Account Details"
+        name: "account_details"
+        file: "content/settings/accounts.yml"
+        fields:
+          - {label: "Bank Name", name: "bank_name", widget: "string"}
+          - {label: "Account Name", name: "account_name", widget: "string"}
+          - {label: "Account Number", name: "account_number", widget: "string"}
+          - {label: "Sort Code", name: "sort_code", widget: "string", required: false}
+          - {label: "Additional Info", name: "additional_info", widget: "text", required: false}
+
+  # Weekly Services Collection
+  - name: "weekly_services"
+    label: "Weekly Services Schedule"
+    folder: "content/weekly"
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - {label: "Service Name", name: "title", widget: "string"}
+      - {label: "Day", name: "day", widget: "select", options: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]}
+      - {label: "Time", name: "time", widget: "string"}
+      - {label: "Description", name: "description", widget: "text", required: false}
+      - {label: "Location", name: "location", widget: "string", default: "Salem African Church, Abekoko Parish"}
+      - {label: "Active", name: "active", widget: "boolean", default: true}
+      - {label: "Order", name: "order", widget: "number", default: 1}

--- a/admin/index.html
+++ b/admin/index.html
@@ -7,127 +7,19 @@
   <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
-  <script>
-    window.CMS_MANUAL_INIT = true;
-  </script>
+  <link href="config.yml" type="text/yaml" rel="cms-config-url">
   <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
   <script>
-    // Enhanced Netlify Identity integration with better redirect handling
+    // Netlify Identity widget redirect handling
     if (window.netlifyIdentity) {
       window.netlifyIdentity.on("init", user => {
-        console.log("Identity initialized, user:", user);
         if (!user) {
-          console.log("No user found, setting up login handler");
           window.netlifyIdentity.on("login", () => {
-            console.log("User logged in, staying on admin page");
-            // Don't redirect, just reload the current page
-            window.location.reload();
+            document.location.href = "/admin/";
           });
-        } else {
-          console.log("User already logged in:", user.email);
         }
       });
-      
-      // Handle logout
-      window.netlifyIdentity.on("logout", () => {
-        console.log("User logged out");
-        window.location.reload();
-      });
-      
-      // Prevent unwanted redirects
-      window.netlifyIdentity.on("close", () => {
-        console.log("Identity widget closed");
-        // Stay on current page
-      });
     }
-
-    CMS.init({
-      config: {
-        backend: {
-          name: 'git-gateway',
-          branch: 'main'
-        },
-        media_folder: 'images/uploads',
-        public_folder: '/images/uploads',
-        collections: [
-          {
-            name: 'sunday_service',
-            label: 'Sunday Service Info',
-            folder: 'content/service',
-            create: true,
-            slug: '{{year}}-{{month}}-{{day}}-service',
-            fields: [
-              {label: 'Title', name: 'title', widget: 'string', default: 'This Sunday\'s Service'},
-              {label: 'Service Date', name: 'service_date', widget: 'string', hint: 'e.g., 27th July, 2025'},
-              {label: 'Collect', name: 'collect', widget: 'string', hint: 'e.g., 6th Sunday After Trinity'},
-              {label: 'Liturgical Colour', name: 'liturgical_colour', widget: 'select', options: ['Red', 'Green', 'Purple', 'White', 'Gold', 'Blue']},
-              {label: 'Theme', name: 'theme', widget: 'string', hint: 'e.g., Minister\'s Appreciation Day'},
-              {label: 'Special Notes', name: 'notes', widget: 'text', required: false}
-            ]
-          },
-          {
-            name: 'church_announcements',
-            label: 'Church Announcements',
-            folder: 'content/announcements',
-            create: true,
-            slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
-            fields: [
-              {label: 'Title', name: 'title', widget: 'string'},
-              {label: 'Category', name: 'category', widget: 'select', options: ['Weekly Services', 'Upcoming Events', 'Church Needs', 'General News']},
-              {label: 'Content', name: 'body', widget: 'markdown'},
-              {label: 'Priority', name: 'priority', widget: 'select', options: ['High', 'Medium', 'Low'], default: 'Medium'},
-              {label: 'Publish Date', name: 'date', widget: 'datetime'}
-            ]
-          },
-          {
-            name: 'weekly_prayers',
-            label: 'Weekly Prayer Points',
-            folder: 'content/prayer',
-            create: true,
-            slug: '{{year}}-week-{{slug}}',
-            fields: [
-              {label: 'Title', name: 'title', widget: 'string', default: 'Prayer Points for the Week'},
-              {label: 'Week Starting', name: 'week_start', widget: 'date'},
-              {label: 'Prayer Points', name: 'prayer_points', widget: 'list', field: {label: 'Prayer Point', name: 'point', widget: 'string'}},
-              {label: 'Food for Thought', name: 'food_for_thought', widget: 'text'},
-              {label: 'Scripture Reference', name: 'scripture', widget: 'string', required: false}
-            ]
-          },
-          {
-            name: 'special_events',
-            label: 'Special Events',
-            folder: 'content/events',
-            create: true,
-            slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
-            fields: [
-              {label: 'Event Title', name: 'title', widget: 'string'},
-              {label: 'Event Date', name: 'event_date', widget: 'datetime'},
-              {label: 'Description', name: 'description', widget: 'text'},
-              {label: 'Event Flyer', name: 'flyer', widget: 'image', required: false},
-              {label: 'Location', name: 'location', widget: 'string', default: 'Salem African Church, Abekoko Parish'},
-              {label: 'Contact Person', name: 'contact', widget: 'string', required: false}
-            ]
-          },
-          {
-            name: 'church_gallery',
-            label: 'Church Photo Gallery',
-            folder: 'content/gallery',
-            create: true,
-            slug: '{{year}}-{{month}}-{{slug}}',
-            fields: [
-              {label: 'Album Title', name: 'title', widget: 'string'},
-              {label: 'Date', name: 'date', widget: 'date'},
-              {label: 'Description', name: 'description', widget: 'text', required: false},
-              {label: 'Photos', name: 'photos', widget: 'list', fields: [
-                {label: 'Image', name: 'image', widget: 'image'},
-                {label: 'Caption', name: 'caption', widget: 'string', required: false}
-              ]},
-              {label: 'Event Type', name: 'category', widget: 'select', options: ['Gethsemane', 'Sunday Service', 'Special Events', 'Community Outreach', 'Other']}
-            ]
-          }
-        ]
-      }
-    });
   </script>
 </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/admin"
+  to = "/admin/index.html"
+  status = 200


### PR DESCRIPTION
This commit fixes the Decap CMS (formerly Netlify CMS) setup to allow login and content management via Netlify Identity.

Key changes:
- The inline CMS configuration has been moved from `admin/index.html` to a dedicated `admin/config.yml` file. The more comprehensive configuration from `admin/config.yml.backup` was used as the base.
- The `admin/index.html` file has been updated to load the configuration from `admin/config.yml` and the Netlify Identity widget script has been simplified for better redirect handling.
- A `netlify.toml` file has been added to the root of the repository. This file includes a redirect rule to ensure that the `/admin` path loads the CMS admin page correctly on Netlify, preventing 404 errors.
- The backend is configured to use `git-gateway` with the `main` branch, and media uploads are directed to `images/uploads` as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a content management system with configurable collections for services, announcements, events, galleries, leadership, settings, and more.
  * Enabled automatic CMS configuration via a centralized settings file.
  * Added a redirect so navigating to /admin loads the admin interface reliably.

* **Refactor**
  * Simplified the admin login flow with a streamlined Netlify Identity redirect.
  * Removed manual CMS initialization and in-page configuration in favor of the centralized setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->